### PR TITLE
Initial README content added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# algolia-woo-indexer
- Index Woocommerce products to Algolia
+# Algolia Woocommerce Indexer
+
+Wordpress plugin that transfers products from Woocommerce to Algolia. 
+
+Currently a work in progress.
+
+Originally intended for private use, but I may improve this and publish it publicly. 


### PR DESCRIPTION
Wordpress plugin that transfers products from Woocommerce to Algolia. 

Currently a work in progress.

Originally intended for private use, but I may improve this and publish it publicly.