### PR TITLE
Fix incompatible type

### DIFF
--- a/classes/class-algolia-woo-indexer.php
+++ b/classes/class-algolia-woo-indexer.php
@@ -68,9 +68,9 @@ if (! class_exists('Algolia_Woo_Indexer')) {
         private static $plugin_url = '';
 
         /**
-         * The Algolia instance
+         * The Algolia static instance
          *
-         * @var string
+         * @var static
          */
         private static $algolia = null;
 


### PR DESCRIPTION
It seems like Algolia\AlgoliaSearch\Se...n_id, $algolia_api_key) of type Algolia\AlgoliaSearch\SearchClient is incompatible with the declared type string of property $algolia