### PR TITLE
Fix instance variable assignment type

### DIFF
--- a/classes/class-algolia-woo-indexer.php
+++ b/classes/class-algolia-woo-indexer.php
@@ -68,9 +68,9 @@ if (! class_exists('Algolia_Woo_Indexer')) {
         private static $plugin_url = '';
 
         /**
-         * The Algolia static instance
+         * The Algolia instance
          *
-         * @var static
+         * @var Algolia\AlgoliaSearch\SearchClient
          */
         private static $algolia = null;
 


### PR DESCRIPTION
It seems like Algolia\AlgoliaSearch\Se...n_id, $algolia_api_key) of type Algolia\AlgoliaSearch\SearchClient is incompatible with the declared type Algowoo\Algolia_Woo_Indexer of property $algolia.