### PR TITLE
Add woocommerce attributes to index data

### DIFF
--- a/classes/class-send-products.php
+++ b/classes/class-send-products.php
@@ -113,7 +113,7 @@ if (!class_exists('Algolia_Send_Products')) {
         public static function get_product_attributes($product)
         {
             $rawAttributes = $product->get_attributes();
-
+            $numericRangeAttributes = ["pa_height", "pa_flowermonth"];
             if (!$rawAttributes) {
                 return false;
             }
@@ -127,12 +127,25 @@ if (!class_exists('Algolia_Send_Products')) {
                 if ($attribute->is_taxonomy()) {
                     $terms = wp_get_post_terms($product->get_id(), $name, 'all');
                     $tax_terms = array();
-                    foreach ($terms as $term) {
-                        $single_term = esc_html($term->name);
-                        array_push($tax_terms, $single_term);
+                    
+                    // interpolate all values when found in numericRangeAttributes
+                    if (array_search($name, $numericRangeAttributes, true) !== false) {
+                        $integers = array();
+                        foreach ($terms as $term) {
+                            array_push($integers, (int) $term->name);
+                        }
+                        for ($i = min($integers); $i <= max($integers); $i++) {
+                            array_push($tax_terms, $i);
+                        }
+                    } else {
+                        // strings
+                        foreach ($terms as $term) {
+                            $single_term = esc_html($term->name);
+                            array_push($tax_terms, $single_term);
+                        }
                     }
-                    $attributes[$name] = $tax_terms; 
                 }
+                $attributes[$name] = $tax_terms;
             }
             return $attributes;
         }

--- a/classes/class-send-products.php
+++ b/classes/class-send-products.php
@@ -112,39 +112,29 @@ if (!class_exists('Algolia_Send_Products')) {
          */
         public static function get_product_attributes($product)
         {
-            $attributes = $product->get_attributes();
+            $rawAttributes = $product->get_attributes();
 
-            if (!$attributes) {
+            if (!$rawAttributes) {
                 return false;
             }
 
-            $output = [];
-            foreach ($attributes as $attribute) {
+            $attributes = [];
+            foreach ($rawAttributes as $attribute) {
                 if ($attribute->get_variation()) {
                     continue;
                 }
                 $name = $attribute->get_name();
                 if ($attribute->is_taxonomy()) {
                     $terms = wp_get_post_terms($product->get_id(), $name, 'all');
-                    $cwtax = $terms[0]->taxonomy;
-                    $cw_object_taxonomy = get_taxonomy($cwtax);
-                    if (isset($cw_object_taxonomy->labels->singular_name)) {
-                        $tax_label = $cw_object_taxonomy->labels->singular_name;
-                    } elseif (isset($cw_object_taxonomy->label)) {
-                        $tax_label = $cw_object_taxonomy->label;
-                        if (0 === strpos($tax_label, 'Product ')) {
-                            $tax_label = substr($tax_label, 8);
-                        }
-                    }
                     $tax_terms = array();
                     foreach ($terms as $term) {
                         $single_term = esc_html($term->name);
                         array_push($tax_terms, $single_term);
                     }
-                    $output[$name] = $tax_terms; 
+                    $attributes[$name] = $tax_terms; 
                 }
             }
-            return $output;
+            return $attributes;
         }
 
         /**

--- a/classes/class-send-products.php
+++ b/classes/class-send-products.php
@@ -104,6 +104,25 @@ if (!class_exists('Algolia_Send_Products')) {
             );
         }
 
+
+        /**
+         * Checks if stock management is enabled and if so, returns quantity and status
+         *
+         * @param  mixed $product Product to check   
+         * @return array ['stock_quantity' => $stock_quantity,'stock_status' => $stock_status] Array with quantity and status. if stock management is disabled, false will be returned,
+         */
+        public static function get_product_stock_data($product)
+        {
+            if ($product->get_manage_stock()) {
+                return array(
+                    'stock_quantity' => $product->get_stock_quantity(),
+                    'stock_status' => $product->get_stock_status()
+                );
+            } else {
+                return false;
+            }
+        }
+
         /**
          * Get attributes from product
          *
@@ -243,7 +262,6 @@ if (!class_exists('Algolia_Send_Products')) {
                 $product_type_price = self::get_product_type_price($product);
                 $sale_price = $product_type_price['sale_price'];
                 $regular_price = $product_type_price['regular_price'];
-
                 /**
                  * Extract image from $product->get_image()
                  */
@@ -261,6 +279,17 @@ if (!class_exists('Algolia_Send_Products')) {
                 $record['sale_price']                    = $sale_price;
                 $record['on_sale']                       = $product->is_on_sale();
                 $record['attributes']                    = self::get_product_attributes($product);
+
+
+                /**
+                 * Add stock information if stock management is on
+                 */
+                $stock_data = self::get_product_stock_data($product);
+                if($stock_data) {
+                    $record = array_merge($record, $stock_data);
+                }
+
+                
                 $records[] = $record;
             }
             wp_reset_postdata();


### PR DESCRIPTION
Hi there,

I like your plugin, fits the basic need very well.
To be able to create some advanced faceting filters I had the need to add the attributes to the index.
May you are interested into this small code addition. 
I kept it straightforward and as simple as possible.

Hope you like it and you may can use.
Some further improvements here would be to add settings for the backend so the user could toggle the indexing of data:
would be nice if the submitted data could be selected - the attributes could be done by listing all available attributes from woocommerce and checkboxes :-) I am quiet short in time so i just added it straight to the code like all the other data as well.

If you have some questions, feel free to ask.

Greets Chris