### PR TITLE
Feature/customizeable dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Note that this plugin is designed for developers developing headless Ecommerce s
 ## Basic Features
 
 -   Manually or automatically submit WooCommerce products to Algolia
+-   Choose from a broad variation of common fields to index
+-   Indexing of attributes with settings for visibility and varation behavios as well as whitelisting.
 -   Default options are added upon plugin activation
 -   Options are deleted from database upon plugin uninstallation (not on deactivation)
 

--- a/algolia-woo-indexer.php
+++ b/algolia-woo-indexer.php
@@ -6,7 +6,7 @@
  * Author:          Daniel Fjeldstad
  * Requires at least: 6.0
  * Tested up to: 6.1.1
- * Requires PHP: 8.1
+ * Requires PHP: 8.0
  * WC requires at least: 7.0.0
  * WC tested up to: 7.4.0
  * Version:         1.0.5

--- a/classes/class-algolia-woo-indexer.php
+++ b/classes/class-algolia-woo-indexer.php
@@ -133,18 +133,18 @@ if (!class_exists('Algolia_Woo_Indexer')) {
                 );
 
                 /**
-                 * Add sections and fields for the data fields
+                 * Add sections and fields for the basic fields
                  */
                 add_settings_section(
                     'algolia_woo_indexer_fields',
-                    esc_html__('Fields to be indexed', 'algolia-woo-indexer'),
+                    esc_html__('Fields indexing settings', 'algolia-woo-indexer'),
                     array($algowooindexer, 'algolia_woo_indexer_fields_section_text'),
                     'algolia_woo_indexer'
                 );
-                foreach (INDEX_FIELDS as $field) {
+                foreach (BASIC_FIELDS as $field) {
                     add_settings_field(
                         'algolia_woo_indexer_field_' . $field,
-                        esc_html__('Field ' . $field, 'algolia-woo-indexer'),
+                        esc_html__($field, 'algolia-woo-indexer'),
                         array($algowooindexer, 'algolia_woo_indexer_field_output'),
                         'algolia_woo_indexer',
                         'algolia_woo_indexer_fields',
@@ -154,6 +154,45 @@ if (!class_exists('Algolia_Woo_Indexer')) {
                         )
                     );
                 }
+
+                /**
+                 * Add sections and fields for the attributes
+                 */
+                add_settings_section(
+                    'algolia_woo_indexer_attributes',
+                    esc_html__('Attributes indexing settings', 'algolia-woo-indexer'),
+                    array($algowooindexer, 'algolia_woo_indexer_attributes_section_text'),
+                    'algolia_woo_indexer'
+                );
+                add_settings_field(
+                    'algolia_woo_indexer_attributes_enabled',
+                    esc_html__('Enable indexing of attributes', 'algolia-woo-indexer'),
+                    array($algowooindexer, 'algolia_woo_indexer_attributes_enabled_output'),
+                    'algolia_woo_indexer',
+                    'algolia_woo_indexer_attributes'
+                );
+                add_settings_field(
+                    'algolia_woo_indexer_attributes_visibility',
+                    esc_html__('Visibility', 'algolia-woo-indexer'),
+                    array($algowooindexer, 'algolia_woo_indexer_attributes_visibility_output'),
+                    'algolia_woo_indexer',
+                    'algolia_woo_indexer_attributes'
+                );
+
+                add_settings_field(
+                    'algolia_woo_indexer_attributes_variation',
+                    esc_html__('Used for variations', 'algolia-woo-indexer'),
+                    array($algowooindexer, 'algolia_woo_indexer_attributes_variation_output'),
+                    'algolia_woo_indexer',
+                    'algolia_woo_indexer_attributes'
+                );
+                add_settings_field(
+                    'algolia_woo_indexer_attributes_list',
+                    esc_html__('Valid Attributes', 'algolia-woo-indexer'),
+                    array($algowooindexer, 'algolia_woo_indexer_attributes_list_output'),
+                    'algolia_woo_indexer',
+                    'algolia_woo_indexer_attributes'
+                );
             }
         }
 
@@ -227,12 +266,95 @@ if (!class_exists('Algolia_Woo_Indexer')) {
          */
         public static function algolia_woo_indexer_field_output($args)
         {
-            $value = get_option(ALGOWOO_DB_OPTION . FIELD_PREFIX . $args["name"]);
+            $value = get_option(ALGOWOO_DB_OPTION . BASIC_FIELD_PREFIX . $args["name"]);
             $isChecked = (!empty($value)) ? 1 : 0;
         ?>
 
             <input id="<?php echo $args["label_for"] ?>" name="<?php echo $args["label_for"] ?>[checked]" type="checkbox" <?php checked(1, $isChecked); ?> />
         <?php
+        }
+
+        /**
+         * Output for attributes if functionality is enabled
+         *
+         * @return void
+         */
+        public static function algolia_woo_indexer_attributes_enabled_output($args)
+        {
+            $value = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_ENABLED);
+            $isChecked = (!empty($value)) ? 1 : 0;
+        ?>
+
+            <input id="algolia_woo_indexer_attributes_enabled" name="algolia_woo_indexer_attributes_enabled[checked]" type="checkbox" <?php checked(1, $isChecked); ?> />
+            <?php
+        }
+
+        /**
+         * Output for attributes how to handle visibility setting
+         *
+         * @return void
+         */
+        public static function algolia_woo_indexer_attributes_visibility_output($args)
+        {
+            $value = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_VISIBILITY);
+            foreach (ATTRIBUTES_VISIBILITY_STATES as $state) {
+                $id = 'algolia_woo_indexer_attributes_visibility_' . $state;
+            ?>
+
+                <p><input id="<?php echo $id; ?>" name="algolia_woo_indexer_attributes_visibility" type="radio" value="<?php echo $state; ?>" <?php checked($state, $value); ?> /><label for="<?php echo $id; ?>"><?php echo esc_html__($state, 'algolia-woo-indexer'); ?></label></p>
+            <?php
+            }
+        }
+
+        /**
+         * Output for attributes how to handle visibility setting
+         *
+         * @return void
+         */
+        public static function algolia_woo_indexer_attributes_variation_output($args)
+        {
+            $value = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_VARIATION);
+            foreach (ATTRIBUTES_VARIATION_STATES as $state) {
+                $id = 'algolia_woo_indexer_attributes_variation_' . $state;
+            ?>
+
+                <p><input id="<?php echo $id; ?>" name="algolia_woo_indexer_attributes_variation" type="radio" value="<?php echo $state; ?>" <?php checked($state, $value); ?> /><label for="<?php echo $id; ?>"><?php echo esc_html__($state, 'algolia-woo-indexer'); ?></label></p>
+            <?php
+            }
+        }
+
+        /**
+         * Output for attributes how to handle visibility setting
+         *
+         * @return void
+         */
+        public static function algolia_woo_indexer_attributes_list_output($args)
+        {
+            $value = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_LIST);
+            $selectedIds = explode(",", $value);
+            $attribute_taxonomies = wc_get_attribute_taxonomies();
+            $taxonomy_terms = array();
+
+            if ($attribute_taxonomies) {
+            ?>
+                <select multiple="multiple" name="algolia_woo_indexer_attributes_list[categorychoice][]">
+                    <?php
+                    foreach ($attribute_taxonomies as $tax) {
+
+                        $id = 'algolia_woo_indexer_attributes_variation_' . $tax->attribute_id;
+                        $label = $tax->attribute_label;
+                        $name = $tax->attribute_name;
+                        $selected = in_array( $id, $selectedIds ) ? ' selected="selected" ' : '';
+                    ?>
+                        <option value="<?php echo $id; ?>" <?php echo $selected; ?>>
+                            <?php echo $label . ' (' . $name . ')'; ?>
+                        </option>
+                    <?php
+                    }
+                    ?>
+                </select>
+            <?php
+            }
         }
 
         /**
@@ -242,16 +364,27 @@ if (!class_exists('Algolia_Woo_Indexer')) {
          */
         public static function algolia_woo_indexer_section_text()
         {
-            echo esc_html__('Enter your settings here', 'algolia-woo-indexer');
+            echo esc_html__('Enter your API settings here.', 'algolia-woo-indexer');
         }
+
         /**
-         * Section text for fields settings section text
+         * Section text for basic fields settings section text
          *
          * @return void
          */
         public static function algolia_woo_indexer_fields_section_text()
         {
-            echo esc_html__('Choose which fields shall be sent to Algolia.', 'algolia-woo-indexer');
+            echo esc_html__('Choose which basic fields shall be indexed.', 'algolia-woo-indexer');
+        }
+
+        /**
+         * Section text for attributes settings section text
+         *
+         * @return void
+         */
+        public static function algolia_woo_indexer_attributes_section_text()
+        {
+            echo esc_html__('Control if and how the attributes shall be indexed.', 'algolia-woo-indexer');
         }
 
         /**
@@ -401,7 +534,7 @@ if (!class_exists('Algolia_Woo_Indexer')) {
              * @see https://www.php.net/manual/en/function.filter-input.php
              */
             $filtered_fields = array();
-            foreach (INDEX_FIELDS as $field) {
+            foreach (BASIC_FIELDS as $field) {
                 $raw_field = filter_input(INPUT_POST, 'algolia_woo_indexer_field_' . $field, FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
                 $filtered_field = (!empty($raw_field)) ? 1 : 0;
                 $filtered_fields[$field] = $filtered_field;
@@ -444,7 +577,7 @@ if (!class_exists('Algolia_Woo_Indexer')) {
             if (isset($filtered_fields) && (!empty($filtered_fields))) {
                 foreach ($filtered_fields as $key => $value) {
                     update_option(
-                        ALGOWOO_DB_OPTION . FIELD_PREFIX . $key,
+                        ALGOWOO_DB_OPTION . BASIC_FIELD_PREFIX . $key,
                         $value
                     );
                 }
@@ -586,11 +719,11 @@ if (!class_exists('Algolia_Woo_Indexer')) {
             /**
              * Set default values for index fields if not already set
              */
-            foreach (INDEX_FIELDS as $field) {
-                $value = get_option(ALGOWOO_DB_OPTION . FIELD_PREFIX . $field);
+            foreach (BASIC_FIELDS as $field) {
+                $value = get_option(ALGOWOO_DB_OPTION . BASIC_FIELD_PREFIX . $field);
                 if (empty($value)) {
                     update_option(
-                        ALGOWOO_DB_OPTION . FIELD_PREFIX . $field,
+                        ALGOWOO_DB_OPTION . BASIC_FIELD_PREFIX . $field,
                         '1'
                     );
                 }

--- a/classes/class-algolia-woo-indexer.php
+++ b/classes/class-algolia-woo-indexer.php
@@ -357,7 +357,12 @@ if (!class_exists('Algolia_Woo_Indexer')) {
          */
         public static function update_settings_options()
         {
-            Algolia_Verify_Nonces::verify_settings_nonce();
+            /**
+             * Do not proceed if nonce for settings is not set
+             */
+            if (false === Algolia_Verify_Nonces::verify_settings_nonce()) {
+                return;
+            }
 
             /**
              * Do not proceed if we are going to send products
@@ -381,9 +386,9 @@ if (!class_exists('Algolia_Woo_Indexer')) {
              *
              * @see https://developer.wordpress.org/reference/functions/sanitize_text_field/
              */
-            $filtered_app_id         = is_array($post_application_id) ? sanitize_text_field($post_application_id['id']) : null;
-            $filtered_api_key        = is_array($post_api_key) ? sanitize_text_field($post_api_key['key']) : null;
-            $filtered_index_name     = is_array($post_index_name) ? sanitize_text_field($post_index_name['name']) : null;
+            $filtered_app_id         = sanitize_text_field($post_application_id['id']);
+            $filtered_api_key        = sanitize_text_field($post_api_key['key']);
+            $filtered_index_name     = sanitize_text_field($post_index_name['name']);
 
             /**
              * Sanitizing by setting the value to either 1 or 0
@@ -391,16 +396,15 @@ if (!class_exists('Algolia_Woo_Indexer')) {
             $filtered_product = (!empty($auto_send)) ? 1 : 0;
 
             /**
-             * Filter the data fields checkboxes and verify that the input is an array and assigned it to an associative array
+             * Filter the data fields checkboxes and verify that the input is an array and assign it to an associative array
              *
              * @see https://www.php.net/manual/en/function.filter-input.php
              */
             $filtered_fields = array();
             foreach (INDEX_FIELDS as $field) {
                 $raw_field = filter_input(INPUT_POST, 'algolia_woo_indexer_field_' . $field, FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
-                if (!empty($raw_field)) {
-                    $filtered_fields[$field] = $raw_field;
-                }
+                $filtered_field = (!empty($raw_field)) ? 1 : 0;
+                $filtered_fields[$field] = $filtered_field;
             }
 
             /**

--- a/classes/class-algolia-woo-indexer.php
+++ b/classes/class-algolia-woo-indexer.php
@@ -228,7 +228,9 @@ if (!class_exists('Algolia_Woo_Indexer')) {
         public static function algolia_woo_indexer_field_output($args)
         {
             $value = get_option(ALGOWOO_DB_OPTION . FIELD_PREFIX . $args["name"]);
-            $isChecked = (!empty($value)) ? 1 : 0; ?>
+            $isChecked = (!empty($value)) ? 1 : 0;
+        ?>
+
             <input id="<?php echo $args["label_for"] ?>" name="<?php echo $args["label_for"] ?>[checked]" type="checkbox" <?php checked(1, $isChecked); ?> />
         <?php
         }
@@ -271,7 +273,6 @@ if (!class_exists('Algolia_Woo_Indexer')) {
          */
         public static function init()
         {
-
             /**
              * Fetch the option to see if we are going to automatically send new products
              */
@@ -380,9 +381,14 @@ if (!class_exists('Algolia_Woo_Indexer')) {
              *
              * @see https://developer.wordpress.org/reference/functions/sanitize_text_field/
              */
-            $filtered_app_id = sanitize_text_field($post_application_id['id']);
-            $filtered_api_key        = sanitize_text_field($post_api_key['key']);
-            $filtered_index_name     = sanitize_text_field($post_index_name['name']);
+            $filtered_app_id         = is_array($post_application_id) ? sanitize_text_field($post_application_id['id']) : null;
+            $filtered_api_key        = is_array($post_api_key) ? sanitize_text_field($post_api_key['key']) : null;
+            $filtered_index_name     = is_array($post_index_name) ? sanitize_text_field($post_index_name['name']) : null;
+
+            /**
+             * Sanitizing by setting the value to either 1 or 0
+             */
+            $filtered_product = (!empty($auto_send)) ? 1 : 0;
 
             /**
              * Filter the data fields checkboxes and verify that the input is an array and assigned it to an associative array
@@ -392,14 +398,10 @@ if (!class_exists('Algolia_Woo_Indexer')) {
             $filtered_fields = array();
             foreach (INDEX_FIELDS as $field) {
                 $raw_field = filter_input(INPUT_POST, 'algolia_woo_indexer_field_' . $field, FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
-                $filtered_field = (!empty($raw_field)) ? 1 : 0;
-                $filtered_fields[$field] = $filtered_field;
+                if (!empty($raw_field)) {
+                    $filtered_fields[$field] = $raw_field;
+                }
             }
-
-            /**
-             * Sanitizing by setting the value to either 1 or 0
-             */
-            $filtered_product = (!empty($auto_send)) ? 1 : 0;
 
             /**
              * Values have been filtered and sanitized

--- a/classes/class-algolia-woo-indexer.php
+++ b/classes/class-algolia-woo-indexer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Main Algolia Woo Indexer class
  * Called from main plugin file algolia-woo-indexer.php
@@ -15,23 +16,23 @@ use \Algowoo\Algolia_Send_Products as Algolia_Send_Products;
 /**
  * Abort if this file is called directly
  */
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+if (!defined('ABSPATH')) {
+    exit;
 }
 
 /**
  * Include plugin file if function is_plugin_active does not exist
  */
-if (! function_exists('is_plugin_active')) {
+if (!function_exists('is_plugin_active')) {
     require_once(ABSPATH . '/wp-admin/includes/plugin.php');
 }
 
-if (! class_exists('Algolia_Woo_Indexer')) {
+if (!class_exists('Algolia_Woo_Indexer')) {
     /**
      * Algolia WooIndexer main class
      */
     // TODO Rename class "Algolia_Woo_Indexer" to match the regular expression ^[A-Z][a-zA-Z0-9]*$.
-     class Algolia_Woo_Indexer
+    class Algolia_Woo_Indexer
     {
         const PLUGIN_NAME      = 'Algolia Woo Indexer';
         const PLUGIN_TRANSIENT = 'algowoo-plugin-notice';
@@ -68,10 +69,10 @@ if (! class_exists('Algolia_Woo_Indexer')) {
         public static function setup_settings_sections()
         {
             /**
-            * Setup arguments for settings sections and fields
-            *
-            * @see https://developer.wordpress.org/reference/functions/register_setting/
-            */
+             * Setup arguments for settings sections and fields
+             *
+             * @see https://developer.wordpress.org/reference/functions/register_setting/
+             */
             if (is_admin()) {
                 $arguments = array(
                     'type'              => 'string',
@@ -92,37 +93,67 @@ if (! class_exists('Algolia_Woo_Indexer')) {
                 add_settings_section(
                     'algolia_woo_indexer_main',
                     esc_html__('Algolia Woo Plugin Settings', 'algolia-woo-indexer'),
-                    array( $algowooindexer, 'algolia_woo_indexer_section_text' ),
+                    array($algowooindexer, 'algolia_woo_indexer_section_text'),
                     'algolia_woo_indexer'
                 );
                 add_settings_field(
                     'algolia_woo_indexer_application_id',
                     esc_html__('Application ID', 'algolia-woo-indexer'),
-                    array( $algowooindexer, 'algolia_woo_indexer_application_id_output' ),
+                    array($algowooindexer, 'algolia_woo_indexer_application_id_output'),
                     'algolia_woo_indexer',
                     'algolia_woo_indexer_main'
                 );
                 add_settings_field(
                     'algolia_woo_indexer_admin_api_key',
                     esc_html__('Admin API Key', 'algolia-woo-indexer'),
-                    array( $algowooindexer, 'algolia_woo_indexer_admin_api_key_output' ),
+                    array($algowooindexer, 'algolia_woo_indexer_admin_api_key_output'),
                     'algolia_woo_indexer',
                     'algolia_woo_indexer_main'
                 );
                 add_settings_field(
                     'algolia_woo_indexer_index_name',
                     esc_html__('Index name (will be created if not existing)', 'algolia-woo-indexer'),
-                    array( $algowooindexer, 'algolia_woo_indexer_index_name_output' ),
+                    array($algowooindexer, 'algolia_woo_indexer_index_name_output'),
                     'algolia_woo_indexer',
                     'algolia_woo_indexer_main'
                 );
                 add_settings_field(
                     'algolia_woo_indexer_automatically_send_new_products',
                     esc_html__('Automatically index new products', 'algolia-woo-indexer'),
-                    array( $algowooindexer, 'algolia_woo_indexer_automatically_send_new_products_output' ),
+                    array($algowooindexer, 'algolia_woo_indexer_automatically_send_new_products_output'),
                     'algolia_woo_indexer',
                     'algolia_woo_indexer_main'
                 );
+                add_settings_field(
+                    'algolia_woo_indexer_automatically_send_new_products',
+                    esc_html__('Automatically index new products', 'algolia-woo-indexer'),
+                    array($algowooindexer, 'algolia_woo_indexer_automatically_send_new_products_output'),
+                    'algolia_woo_indexer',
+                    'algolia_woo_indexer_main'
+                );
+
+                /**
+                 * Add sections and fields for the data fields
+                 */
+                add_settings_section(
+                    'algolia_woo_indexer_fields',
+                    esc_html__('Fields to be indexed', 'algolia-woo-indexer'),
+                    array($algowooindexer, 'algolia_woo_indexer_fields_section_text'),
+                    'algolia_woo_indexer'
+                );
+                foreach (INDEX_FIELDS as $field) {
+                    add_settings_field(
+                        'algolia_woo_indexer_field_' . $field,
+                        esc_html__('Field ' . $field, 'algolia-woo-indexer'),
+                        array($algowooindexer, 'algolia_woo_indexer_field_output'),
+                        'algolia_woo_indexer',
+                        'algolia_woo_indexer_fields',
+                        array(
+                            'label_for' => 'algolia_woo_indexer_field_' . $field,
+                            'name' => $field
+                        )
+                    );
+                }
             }
         }
 
@@ -171,7 +202,7 @@ if (! class_exists('Algolia_Woo_Indexer')) {
             echo "<input id='algolia_woo_indexer_index_name' name='algolia_woo_indexer_index_name[name]'
 				type='text' value='" . esc_attr($index_name) . "' />";
         }
-        
+
         /**
          * Output for checkbox to check if we automatically send new products to Algolia
          *
@@ -184,10 +215,22 @@ if (! class_exists('Algolia_Woo_Indexer')) {
              * But I have still done it to be 100% safe
              */
             $auto_send = get_option(ALGOWOO_DB_OPTION . AUTOMATICALLY_SEND_NEW_PRODUCTS);
-            $auto_send = (! empty($auto_send)) ? 1 : 0; ?>
-			<input id="algolia_woo_indexer_automatically_send_new_products" name="algolia_woo_indexer_automatically_send_new_products[checked]"
-			type="checkbox" <?php checked(1, $auto_send); ?> />
-			<?php
+            $auto_send = (!empty($auto_send)) ? 1 : 0; ?>
+            <input id="algolia_woo_indexer_automatically_send_new_products" name="algolia_woo_indexer_automatically_send_new_products[checked]" type="checkbox" <?php checked(1, $auto_send); ?> />
+        <?php
+        }
+
+        /**
+         * Output for fields which data shall be sent to Algolia
+         *
+         * @return void
+         */
+        public static function algolia_woo_indexer_field_output($args)
+        {
+            $value = get_option(ALGOWOO_DB_OPTION . FIELD_PREFIX . $args["name"]);
+            $isChecked = (!empty($value)) ? 1 : 0; ?>
+            <input id="<?php echo $args["label_for"] ?>" name="<?php echo $args["label_for"] ?>[checked]" type="checkbox" <?php checked(1, $isChecked); ?> />
+        <?php
         }
 
         /**
@@ -198,6 +241,15 @@ if (! class_exists('Algolia_Woo_Indexer')) {
         public static function algolia_woo_indexer_section_text()
         {
             echo esc_html__('Enter your settings here', 'algolia-woo-indexer');
+        }
+        /**
+         * Section text for fields settings section text
+         *
+         * @return void
+         */
+        public static function algolia_woo_indexer_fields_section_text()
+        {
+            echo esc_html__('Choose which fields shall be sent to Algolia.', 'algolia-woo-indexer');
         }
 
         /**
@@ -230,7 +282,7 @@ if (! class_exists('Algolia_Woo_Indexer')) {
              */
             Algolia_Check_Requirements::check_unmet_requirements();
 
-            if (! Algolia_Check_Requirements::algolia_wp_version_check() || ! Algolia_Check_Requirements::algolia_php_version_check()) {
+            if (!Algolia_Check_Requirements::algolia_wp_version_check() || !Algolia_Check_Requirements::algolia_php_version_check()) {
                 add_action(
                     'admin_notices',
                     function () {
@@ -246,28 +298,28 @@ if (! class_exists('Algolia_Woo_Indexer')) {
             /**
              * Setup translations
              */
-            add_action('plugins_loaded', array( $ob_class, 'load_textdomain' ));
+            add_action('plugins_loaded', array($ob_class, 'load_textdomain'));
 
             /**
              * Add actions to setup admin menu
              */
             if (is_admin()) {
-                add_action('admin_menu', array( $ob_class, 'admin_menu' ));
-                add_action('admin_init', array( $ob_class, 'setup_settings_sections' ));
-                add_action('admin_init', array( $ob_class, 'update_settings_options' ));
-                add_action('admin_init', array( $ob_class, 'maybe_send_products' ));
+                add_action('admin_menu', array($ob_class, 'admin_menu'));
+                add_action('admin_init', array($ob_class, 'setup_settings_sections'));
+                add_action('admin_init', array($ob_class, 'update_settings_options'));
+                add_action('admin_init', array($ob_class, 'maybe_send_products'));
 
                 /**
                  * Register hook to automatically send new products if the option is set
                  */
 
                 if ('1' === $auto_send) {
-                    add_action('save_post', array( $ob_class, 'send_new_product_to_algolia' ), 10, 3);
+                    add_action('save_post', array($ob_class, 'send_new_product_to_algolia'), 10, 3);
                 }
 
                 self::$plugin_url = admin_url('options-general.php?page=algolia-woo-indexer-settings');
 
-                if (! is_plugin_active('woocommerce/woocommerce.php')) {
+                if (!is_plugin_active('woocommerce/woocommerce.php')) {
                     add_action(
                         'admin_notices',
                         function () {
@@ -321,7 +373,7 @@ if (! class_exists('Algolia_Woo_Indexer')) {
             $post_application_id             = filter_input(INPUT_POST, 'algolia_woo_indexer_application_id', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
             $post_api_key                    = filter_input(INPUT_POST, 'algolia_woo_indexer_admin_api_key', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
             $post_index_name                 = filter_input(INPUT_POST, 'algolia_woo_indexer_index_name', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
-            $auto_send = filter_input(INPUT_POST, 'algolia_woo_indexer_automatically_send_new_products', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
+            $auto_send                       = filter_input(INPUT_POST, 'algolia_woo_indexer_automatically_send_new_products', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
 
             /**
              * Properly sanitize text fields before updating data
@@ -333,9 +385,21 @@ if (! class_exists('Algolia_Woo_Indexer')) {
             $filtered_index_name     = sanitize_text_field($post_index_name['name']);
 
             /**
+             * Filter the data fields checkboxes and verify that the input is an array and assigned it to an associative array
+             *
+             * @see https://www.php.net/manual/en/function.filter-input.php
+             */
+            $filtered_fields = array();
+            foreach (INDEX_FIELDS as $field) {
+                $raw_field = filter_input(INPUT_POST, 'algolia_woo_indexer_field_' . $field, FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
+                $filtered_field = (!empty($raw_field)) ? 1 : 0;
+                $filtered_fields[$field] = $filtered_field;
+            }
+
+            /**
              * Sanitizing by setting the value to either 1 or 0
              */
-            $filtered_product = (! empty($auto_send)) ? 1 : 0;
+            $filtered_product = (!empty($auto_send)) ? 1 : 0;
 
             /**
              * Values have been filtered and sanitized
@@ -343,32 +407,41 @@ if (! class_exists('Algolia_Woo_Indexer')) {
              *
              * @see https://developer.wordpress.org/reference/functions/update_option/
              */
-            if (isset($filtered_app_id) && (! empty($filtered_app_id))) {
+            if (isset($filtered_app_id) && (!empty($filtered_app_id))) {
                 update_option(
                     ALGOWOO_DB_OPTION . ALGOLIA_APP_ID,
                     $filtered_app_id
                 );
             }
 
-            if (isset($filtered_api_key) && (! empty($filtered_api_key))) {
+            if (isset($filtered_api_key) && (!empty($filtered_api_key))) {
                 update_option(
                     ALGOWOO_DB_OPTION . ALGOLIA_API_KEY,
                     $filtered_api_key
                 );
             }
 
-            if (isset($filtered_index_name) && (! empty($filtered_index_name))) {
+            if (isset($filtered_index_name) && (!empty($filtered_index_name))) {
                 update_option(
                     ALGOWOO_DB_OPTION . INDEX_NAME,
                     $filtered_index_name
                 );
             }
 
-            if (isset($filtered_product) && (! empty($filtered_product))) {
+            if (isset($filtered_product) && (!empty($filtered_product))) {
                 update_option(
                     ALGOWOO_DB_OPTION . AUTOMATICALLY_SEND_NEW_PRODUCTS,
                     $filtered_product
                 );
+            }
+
+            if (isset($filtered_fields) && (!empty($filtered_fields))) {
+                foreach ($filtered_fields as $key => $value) {
+                    update_option(
+                        ALGOWOO_DB_OPTION . FIELD_PREFIX . $key,
+                        $value
+                    );
+                }
             }
         }
 
@@ -412,7 +485,7 @@ if (! class_exists('Algolia_Woo_Indexer')) {
                 esc_html__('Algolia Woo Indexer Settings', 'algolia-woo-indexer'),
                 'manage_options',
                 'algolia-woo-indexer-settings',
-                array( get_called_class(), 'algolia_woo_indexer_settings' )
+                array(get_called_class(), 'algolia_woo_indexer_settings')
             );
         }
 
@@ -424,26 +497,26 @@ if (! class_exists('Algolia_Woo_Indexer')) {
         public static function algolia_woo_indexer_settings()
         {
             /**
-            * Verify that the user can access the settings page
-            */
-            if (! current_user_can('manage_options')) {
+             * Verify that the user can access the settings page
+             */
+            if (!current_user_can('manage_options')) {
                 wp_die(esc_html__('Action not allowed.', 'algolia_woo_indexer_settings'));
             } ?>
-			<div class="wrap">
-				<h1><?php esc_html__('Algolia Woo Indexer Settings', 'algolia-woo-indexer'); ?></h1>
-				<form action="<?php echo esc_url(self::$plugin_url); ?>" method="POST">
-			<?php
-            settings_fields('algolia_woo_options');
-            do_settings_sections('algolia_woo_indexer');
-            submit_button('', 'primary wide'); ?>
-				</form>
-				<form action="<?php echo esc_url(self::$plugin_url); ?>" method="POST">
-					<?php wp_nonce_field('send_products_to_algolia_nonce_action', 'send_products_to_algolia_nonce_name'); ?>
-					<input type="hidden" name="send_products_to_algolia" id="send_products_to_algolia" value="true" />
-					<?php submit_button(esc_html__('Send products to Algolia', 'algolia_woo_indexer_settings'), 'primary wide', '', false); ?>
-				</form>
-			</div>
-			<?php
+            <div class="wrap">
+                <h1><?php esc_html__('Algolia Woo Indexer Settings', 'algolia-woo-indexer'); ?></h1>
+                <form action="<?php echo esc_url(self::$plugin_url); ?>" method="POST">
+                    <?php
+                    settings_fields('algolia_woo_options');
+                    do_settings_sections('algolia_woo_indexer');
+                    submit_button('', 'primary wide'); ?>
+                </form>
+                <form action="<?php echo esc_url(self::$plugin_url); ?>" method="POST">
+                    <?php wp_nonce_field('send_products_to_algolia_nonce_action', 'send_products_to_algolia_nonce_name'); ?>
+                    <input type="hidden" name="send_products_to_algolia" id="send_products_to_algolia" value="true" />
+                    <?php submit_button(esc_html__('Send products to Algolia', 'algolia_woo_indexer_settings'), 'primary wide', '', false); ?>
+                </form>
+            </div>
+<?php
         }
 
         /**
@@ -453,7 +526,7 @@ if (! class_exists('Algolia_Woo_Indexer')) {
          */
         public static function get_instance()
         {
-            if (! self::$instance) {
+            if (!self::$instance) {
                 self::$instance = new Algolia_Woo_Indexer();
             }
             return self::$instance;
@@ -474,7 +547,8 @@ if (! class_exists('Algolia_Woo_Indexer')) {
             $algolia_application_id          = get_option(ALGOWOO_DB_OPTION . ALGOLIA_APP_ID);
             $algolia_api_key                 = get_option(ALGOWOO_DB_OPTION . ALGOLIA_API_KEY);
             $algolia_index_name              = get_option(ALGOWOO_DB_OPTION . INDEX_NAME);
-            
+            $algolia_index_name              = get_option(ALGOWOO_DB_OPTION . INDEX_NAME);
+
             if (empty($auto_send)) {
                 add_option(
                     ALGOWOO_DB_OPTION . AUTOMATICALLY_SEND_NEW_PRODUCTS,
@@ -502,6 +576,22 @@ if (! class_exists('Algolia_Woo_Indexer')) {
                     'Change me'
                 );
             }
+
+            /**
+             * Set default values for index fields if not already set
+             */
+            foreach (INDEX_FIELDS as $field) {
+                $value = get_option(ALGOWOO_DB_OPTION . FIELD_PREFIX . $field);
+                if (empty($value)) {
+                    update_option(
+                        ALGOWOO_DB_OPTION . FIELD_PREFIX . $field,
+                        '1'
+                    );
+                }
+            }
+
+
+
             set_transient(self::PLUGIN_TRANSIENT, true);
         }
 

--- a/classes/class-algolia-woo-indexer.php
+++ b/classes/class-algolia-woo-indexer.php
@@ -269,7 +269,6 @@ if (!class_exists('Algolia_Woo_Indexer')) {
             $value = get_option(ALGOWOO_DB_OPTION . BASIC_FIELD_PREFIX . $args["name"]);
             $isChecked = (!empty($value)) ? 1 : 0;
         ?>
-
             <input id="<?php echo $args["label_for"] ?>" name="<?php echo $args["label_for"] ?>[checked]" type="checkbox" <?php checked(1, $isChecked); ?> />
         <?php
         }
@@ -284,7 +283,6 @@ if (!class_exists('Algolia_Woo_Indexer')) {
             $value = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_ENABLED);
             $isChecked = (!empty($value)) ? 1 : 0;
         ?>
-
             <input id="algolia_woo_indexer_attributes_enabled" name="algolia_woo_indexer_attributes_enabled[checked]" type="checkbox" <?php checked(1, $isChecked); ?> />
             <?php
         }
@@ -300,7 +298,6 @@ if (!class_exists('Algolia_Woo_Indexer')) {
             foreach (ATTRIBUTES_VISIBILITY_STATES as $state) {
                 $id = 'algolia_woo_indexer_attributes_visibility_' . $state;
             ?>
-
                 <p><input id="<?php echo $id; ?>" name="algolia_woo_indexer_attributes_visibility[value]" type="radio" value="<?php echo $state; ?>" <?php checked($state, $value); ?> /><label for="<?php echo $id; ?>"><?php echo esc_html__($state, 'algolia-woo-indexer'); ?></label></p>
             <?php
             }
@@ -317,7 +314,6 @@ if (!class_exists('Algolia_Woo_Indexer')) {
             foreach (ATTRIBUTES_VARIATION_STATES as $state) {
                 $id = 'algolia_woo_indexer_attributes_variation_' . $state;
             ?>
-
                 <p><input id="<?php echo $id; ?>" name="algolia_woo_indexer_attributes_variation[value]" type="radio" value="<?php echo $state; ?>" <?php checked($state, $value); ?> /><label for="<?php echo $id; ?>"><?php echo esc_html__($state, 'algolia-woo-indexer'); ?></label></p>
             <?php
             }
@@ -343,7 +339,7 @@ if (!class_exists('Algolia_Woo_Indexer')) {
                         $id = $tax->attribute_id;
                         $label = $tax->attribute_label;
                         $name = $tax->attribute_name;
-                        $selected = in_array( $id, $selectedIds ) ? ' selected="selected" ' : '';
+                        $selected = in_array($id, $selectedIds) ? ' selected="selected" ' : '';
                     ?>
                         <option value="<?php echo $id; ?>" <?php echo $selected; ?>>
                             <?php echo $label . ' (' . $name . ')'; ?>
@@ -527,16 +523,16 @@ if (!class_exists('Algolia_Woo_Indexer')) {
             $filtered_index_name     = sanitize_text_field($post_index_name['name']);
             $filtered_attributes_visibility     = sanitize_text_field($attributes_visibility['value']);
             $filtered_attributes_variation     = sanitize_text_field($attributes_variation['value']);
-            
+
             /**
              * sanitize select list of id's by getting integers and them implode seperated with comma
              */
 
             $attributes_list_integers = [];
-            foreach($attributes_list['list'] as $id) {
+            foreach ($attributes_list['list'] as $id) {
                 array_push($attributes_list_integers, (int) $id);
             }
-            $filtered_attributes_list = implode(',',$attributes_list_integers);
+            $filtered_attributes_list = implode(',', $attributes_list_integers);
 
             /**
              * Sanitizing by setting the value to either 1 or 0
@@ -583,21 +579,14 @@ if (!class_exists('Algolia_Woo_Indexer')) {
                 );
             }
 
-            if (isset($filtered_product) && (!empty($filtered_product))) {
+            if (isset($filtered_product)) {
                 update_option(
                     ALGOWOO_DB_OPTION . AUTOMATICALLY_SEND_NEW_PRODUCTS,
                     $filtered_product
                 );
             }
 
-            if (isset($filtered_attributes_enabled) && (!empty($filtered_attributes_enabled))) {
-                update_option(
-                    ALGOWOO_DB_OPTION . ATTRIBUTES_ENABLED,
-                    $filtered_attributes_enabled
-                );
-            }
-
-            if (isset($filtered_attributes_enabled) && (!empty($filtered_attributes_enabled))) {
+            if (isset($filtered_attributes_enabled)) {
                 update_option(
                     ALGOWOO_DB_OPTION . ATTRIBUTES_ENABLED,
                     $filtered_attributes_enabled
@@ -617,6 +606,7 @@ if (!class_exists('Algolia_Woo_Indexer')) {
                     $filtered_attributes_variation
                 );
             }
+
             if (isset($filtered_attributes_list) && (!empty($filtered_attributes_list))) {
                 update_option(
                     ALGOWOO_DB_OPTION . ATTRIBUTES_LIST,
@@ -737,9 +727,9 @@ if (!class_exists('Algolia_Woo_Indexer')) {
             $algolia_api_key                 = get_option(ALGOWOO_DB_OPTION . ALGOLIA_API_KEY);
             $algolia_index_name              = get_option(ALGOWOO_DB_OPTION . INDEX_NAME);
             $attributes_enabled              = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_ENABLED);
-            $attributes_visibility              = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_VISIBILITY);
-            $attributes_variation              = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_VARIATION);
-            $attributes_list              = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_LIST);
+            $attributes_visibility           = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_VISIBILITY);
+            $attributes_variation            = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_VARIATION);
+            $attributes_list                 = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_LIST);
 
             if (empty($auto_send)) {
                 add_option(

--- a/classes/class-algolia-woo-indexer.php
+++ b/classes/class-algolia-woo-indexer.php
@@ -335,33 +335,13 @@ if (!class_exists('Algolia_Woo_Indexer')) {
         {
             $value = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_LIST);
             $selectedIds = explode(",", $value);
-            $attribute_taxonomies = wc_get_attribute_taxonomies();
-
-            if ($attribute_taxonomies) {
-            ?>
-            <p><?php echo __('Here you can whitelist all the attributes. Use the <b>shift</b> or <b>control</b> buttons to select multiple attributes.', 'algolia-woo-indexer'); ?></p>
-                <select multiple="multiple" name="algolia_woo_indexer_attributes_list[list][]" size="<?php echo count($attribute_taxonomies); ?>">
-                    <?php
-                    foreach ($attribute_taxonomies as $tax) {
-
-                        $id = $tax->attribute_id;
-                        $label = $tax->attribute_label;
-                        $name = $tax->attribute_name;
-                        $selected = in_array($id, $selectedIds) ? ' selected="selected" ' : '';
-                    ?>
-                        <option value="<?php echo $id; ?>" <?php echo $selected; ?>>
-                            <?php echo $label . ' (' . $name . ')'; ?>
-                        </option>
-                    <?php
-                    }
-                    ?>
-                </select>
-            <?php
-            }
+            $name = "algolia_woo_indexer_attributes_list[list]";
+            $description = __('Here you can whitelist all the attributes. Use the <b>shift</b> or <b>control</b> buttons to select multiple attributes.', 'algolia-woo-indexer');
+            self::generic_attributes_select_output($name, $selectedIds, $description);
         }
 
         /**
-         * Output for attributes list which attributes are whitelisted
+         * Output for attributes list which are using a numeric interpolation
          *
          * @return void
          */
@@ -369,29 +349,44 @@ if (!class_exists('Algolia_Woo_Indexer')) {
         {
             $value = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_LIST_INTERPOLATE);
             $selectedIds = explode(",", $value);
+            $name = "algolia_woo_indexer_attributes_list_interpolate[list]";
+            $description = __('If you have some attributes based on number which shall be interpolated between the lowest to the highest number, you can select it here. A common usecase for this is if you want to have a <b>range slider</b> in aloglia which works for a certain range. Example: a plant grows between 20 and 25cm tall. for this you enter 20 and 25 as attribute values to your product and it will automatically extend the data to [20,21,22,23,24,25]', 'algolia-woo-indexer');
+            self::generic_attributes_select_output($name, $selectedIds, $description);
+        }
+
+        /**
+         * Generic Output for attributes list where attributes are whitelisted
+         *
+         * @return void
+         */
+        public static function generic_attributes_select_output($name, $selectedIds, $description)
+        {
             $attribute_taxonomies = wc_get_attribute_taxonomies();
 
-            if ($attribute_taxonomies) {
-            ?>
-            <p><?php echo __('If you have some attributes based on number which shall be interpolated between the lowest to the highest number, you can select it here. A common usecase for this is if you want to have a <b>range slider</b> in aloglia which works for a certain range. Example: a plant grows between 20 and 25cm tall. for this you enter 20 and 25 as attribute values to your product and it will automatically extend the data to [20,21,22,23,24,25]', 'algolia-woo-indexer'); ?></p>
-                <select multiple="multiple" name="algolia_woo_indexer_attributes_list_interpolate[list][]" size="<?php echo count($attribute_taxonomies); ?>">
-                    <?php
-                    foreach ($attribute_taxonomies as $tax) {
-
-                        $id = $tax->attribute_id;
-                        $label = $tax->attribute_label;
-                        $name = $tax->attribute_name;
-                        $selected = in_array($id, $selectedIds) ? ' selected="selected" ' : '';
-                    ?>
-                        <option value="<?php echo $id; ?>" <?php echo $selected; ?>>
-                            <?php echo $label . ' (' . $name . ')'; ?>
-                        </option>
-                    <?php
-                    }
-                    ?>
-                </select>
-            <?php
+            if (!$attribute_taxonomies) {
+                echo esc_html__('You don\'t have any attributes defined yet. Go to WooCommerce and add some to use this feature.', 'algolia-woo-indexer');
+                return;
             }
+            ?>
+            <p><?php echo $description; ?></p>
+            <select multiple="multiple" name="<?php echo $name; ?>[]" size="<?php echo count($attribute_taxonomies); ?>">
+                <?php
+                foreach ($attribute_taxonomies as $tax) {
+
+                    $id = $tax->attribute_id;
+                    $label = $tax->attribute_label;
+                    $name = $tax->attribute_name;
+                    $selected = in_array($id, $selectedIds) ? ' selected="selected" ' : '';
+                ?>
+                    <option value="<?php echo $id; ?>" <?php echo $selected; ?>>
+                        <?php echo $label . ' (' . $name . ')'; ?>
+                    </option>
+                <?php
+                }
+                ?>
+            </select>
+        <?php
+
         }
 
         /**

--- a/classes/class-algolia-woo-indexer.php
+++ b/classes/class-algolia-woo-indexer.php
@@ -124,13 +124,6 @@ if (!class_exists('Algolia_Woo_Indexer')) {
                     'algolia_woo_indexer',
                     'algolia_woo_indexer_main'
                 );
-                add_settings_field(
-                    'algolia_woo_indexer_automatically_send_new_products',
-                    esc_html__('Automatically index new products', 'algolia-woo-indexer'),
-                    array($algowooindexer, 'algolia_woo_indexer_automatically_send_new_products_output'),
-                    'algolia_woo_indexer',
-                    'algolia_woo_indexer_main'
-                );
 
                 /**
                  * Add sections and fields for the basic fields
@@ -271,7 +264,7 @@ if (!class_exists('Algolia_Woo_Indexer')) {
          *
          * @return void
          */
-        public static function algolia_woo_indexer_field_output($args)
+        public static function algolia_woo_indexer_field_output()
         {
             $value = get_option(ALGOWOO_DB_OPTION . BASIC_FIELD_PREFIX . $args["name"]);
             $isChecked = (!empty($value)) ? 1 : 0;
@@ -285,7 +278,7 @@ if (!class_exists('Algolia_Woo_Indexer')) {
          *
          * @return void
          */
-        public static function algolia_woo_indexer_attributes_enabled_output($args)
+        public static function algolia_woo_indexer_attributes_enabled_output()
         {
             $value = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_ENABLED);
             $isChecked = (!empty($value)) ? 1 : 0;
@@ -299,7 +292,7 @@ if (!class_exists('Algolia_Woo_Indexer')) {
          *
          * @return void
          */
-        public static function algolia_woo_indexer_attributes_visibility_output($args)
+        public static function algolia_woo_indexer_attributes_visibility_output()
         {
             $value = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_VISIBILITY);
             foreach (ATTRIBUTES_VISIBILITY_STATES as $state) {
@@ -315,7 +308,7 @@ if (!class_exists('Algolia_Woo_Indexer')) {
          *
          * @return void
          */
-        public static function algolia_woo_indexer_attributes_variation_output($args)
+        public static function algolia_woo_indexer_attributes_variation_output()
         {
             $value = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_VARIATION);
             foreach (ATTRIBUTES_VARIATION_STATES as $state) {
@@ -331,7 +324,7 @@ if (!class_exists('Algolia_Woo_Indexer')) {
          *
          * @return void
          */
-        public static function algolia_woo_indexer_attributes_list_output($args)
+        public static function algolia_woo_indexer_attributes_list_output()
         {
             $value = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_LIST);
             $selectedIds = explode(",", $value);
@@ -345,7 +338,7 @@ if (!class_exists('Algolia_Woo_Indexer')) {
          *
          * @return void
          */
-        public static function algolia_woo_indexer_attributes_list_interpolate_output($args)
+        public static function algolia_woo_indexer_attributes_list_interpolate_output()
         {
             $value = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_LIST_INTERPOLATE);
             $selectedIds = explode(",", $value);
@@ -571,11 +564,11 @@ if (!class_exists('Algolia_Woo_Indexer')) {
                 array_push($attributes_list_integers, (int) $id);
             }
             $filtered_attributes_list = implode(',', $attributes_list_integers);
-            $attributes_list_interpolate_integers = [];
+            $attributes_list_interp_int = [];
             foreach ($attributes_list_interpolate['list'] as $id) {
-                array_push($attributes_list_interpolate_integers, (int) $id);
+                array_push($attributes_list_interp_int, (int) $id);
             }
-            $filtered_attributes_list_interpolate = implode(',', $attributes_list_interpolate_integers);
+            $clean_attributes_list_interp = implode(',', $attributes_list_interp_int);
 
             /**
              * Sanitizing by setting the value to either 1 or 0
@@ -657,10 +650,10 @@ if (!class_exists('Algolia_Woo_Indexer')) {
                 );
             }
 
-            if (isset($filtered_attributes_list_interpolate) && (!empty($filtered_attributes_list_interpolate))) {
+            if (isset($clean_attributes_list_interp) && (!empty($clean_attributes_list_interp))) {
                 update_option(
                     ALGOWOO_DB_OPTION . ATTRIBUTES_LIST_INTERPOLATE,
-                    $filtered_attributes_list_interpolate
+                    $clean_attributes_list_interp
                 );
             }
 

--- a/classes/class-send-products.php
+++ b/classes/class-send-products.php
@@ -39,7 +39,7 @@ define('CHANGE_ME', 'change me');
 /**
  * Define list of fields available to index
  */
-define('INDEX_FIELDS', array(
+define('BASIC_FIELDS', array(
     'permalink', 
     'tags', 
     'categories', 
@@ -59,9 +59,20 @@ define('INDEX_FIELDS', array(
  */
 define('INDEX_NAME', '_index_name');
 define('AUTOMATICALLY_SEND_NEW_PRODUCTS', '_automatically_send_new_products');
-define('FIELD_PREFIX', '_field_');
+define('BASIC_FIELD_PREFIX', '_field_');
 define('ALGOLIA_APP_ID', '_application_id');
 define('ALGOLIA_API_KEY', '_admin_api_key');
+
+/**
+ * constants for attributes
+ */
+define('ATTRIBUTES_ENABLED', '_attributes_enabled');
+define('ATTRIBUTES_VISIBILITY', '_attributes_visibility');
+define('ATTRIBUTES_VISIBILITY_STATES', array('both', 'visible', 'hidden'));
+define('ATTRIBUTES_VARIATION', '_attributes_variation');
+define('ATTRIBUTES_VARIATION_STATES', array('both', 'used', 'notused'));
+define('ATTRIBUTES_LIST', '_attributes_list');
+
 
 if (!class_exists('Algolia_Send_Products')) {
     /**
@@ -103,12 +114,12 @@ if (!class_exists('Algolia_Send_Products')) {
         /**
          * check if the field is enabled and shall be sent
          *
-         * @param  mixed $field name of field to be checked according to INDEX_FIELDS 
+         * @param  mixed $field name of field to be checked according to BASIC_FIELDS 
          * @return boolean true if enable, false is not enabled
          */
         public static function is_field_enabled($field)
         {
-            $fieldValue = get_option(ALGOWOO_DB_OPTION . FIELD_PREFIX . $field);
+            $fieldValue = get_option(ALGOWOO_DB_OPTION . BASIC_FIELD_PREFIX . $field);
             return $fieldValue;
         }
 
@@ -116,7 +127,7 @@ if (!class_exists('Algolia_Send_Products')) {
          * helper function to add a field to a record while checking their state
          *
          * @param  array $record existing record where the field and value shall be added to 
-         * @param  string $field name of field to be checked according to INDEX_FIELDS 
+         * @param  string $field name of field to be checked according to BASIC_FIELDS 
          * @param  mixed $value data to be added to the record array named to $field
          * @return array $record previous passed $record with added field data
          */

--- a/classes/class-send-products.php
+++ b/classes/class-send-products.php
@@ -37,10 +37,16 @@ define('ALGOWOO_CURRENT_DB_VERSION', '0.3');
 define('CHANGE_ME', 'change me');
 
 /**
+ * Define list of fields available to index
+ */
+define('INDEX_FIELDS', ['permalink', 'tags', 'categories', 'short_description', 'product_name', 'product_image', 'regular_price', 'sale_price', 'on_sale', 'attributes']);
+
+/**
  * Database table names
  */
 define('INDEX_NAME', '_index_name');
 define('AUTOMATICALLY_SEND_NEW_PRODUCTS', '_automatically_send_new_products');
+define('FIELD_PREFIX', '_field_');
 define('ALGOLIA_APP_ID', '_application_id');
 define('ALGOLIA_API_KEY', '_admin_api_key');
 
@@ -133,9 +139,11 @@ if (!class_exists('Algolia_Send_Products')) {
         {
             $tags = get_the_terms($product->get_id(), 'product_tag');
             $term_array = array();
-            foreach ($tags as $tag) {
-                $name = get_term($tag)->name;
-                array_push($term_array, $name);
+            if (is_array($tags)) {
+                foreach ($tags as $tag) {
+                    $name = get_term($tag)->name;
+                    array_push($term_array, $name);
+                }
             }
             return $term_array;
         }
@@ -154,7 +162,7 @@ if (!class_exists('Algolia_Send_Products')) {
                 $name = get_term($category)->name;
                 $slug = get_term($category)->slug;
                 array_push($term_array, array(
-                    "name" => $name, 
+                    "name" => $name,
                     "slug" => $slug
                 ));
             }

--- a/classes/class-send-products.php
+++ b/classes/class-send-products.php
@@ -184,9 +184,8 @@ if (!class_exists('Algolia_Send_Products')) {
                     'stock_quantity' => $product->get_stock_quantity(),
                     'stock_status' => $product->get_stock_status()
                 );
-            } else {
-                return false;
             }
+            return false;
         }
 
         /**
@@ -304,7 +303,9 @@ if (!class_exists('Algolia_Send_Products')) {
                     $terms = wp_get_post_terms($product->get_id(), $name, 'all');
                     $tax_terms = array();
 
-                    // interpolate all values when found in numericRangeAttributes
+                    /**
+                     * interpolate all values when specified to interpolate
+                     */
                     if (in_array($id, $setting_ids_interpolate)) {
                         $integers = array();
                         foreach ($terms as $term) {
@@ -315,8 +316,12 @@ if (!class_exists('Algolia_Send_Products')) {
                                 array_push($tax_terms, $i);
                             }
                         }
-                    } else {
-                        // strings
+                    }
+
+                    /**
+                     * normal mixed content case 
+                     */
+                    if (!in_array($id, $setting_ids_interpolate)) {
                         foreach ($terms as $term) {
                             $single_term = esc_html($term->name);
                             array_push($tax_terms, $single_term);

--- a/classes/class-send-products.php
+++ b/classes/class-send-products.php
@@ -67,13 +67,20 @@ define('ALGOLIA_API_KEY', '_admin_api_key');
 /**
  * constants for attributes
  */
+define('ATTRIBUTES_SETTINGS', array(
+    'enabled' => 'Enable indexing of attributes',
+    'visibility' => 'Visibility',
+    'variation' => 'Used for variations',
+    'list' => 'Valid Attributes',
+    'interp' => 'Numeric Interpolation'
+));
 define('ATTRIBUTES_ENABLED', '_attributes_enabled');
 define('ATTRIBUTES_VISIBILITY', '_attributes_visibility');
 define('ATTRIBUTES_VISIBILITY_STATES', array('all', 'visible', 'hidden'));
 define('ATTRIBUTES_VARIATION', '_attributes_variation');
 define('ATTRIBUTES_VARIATION_STATES', array('all', 'used', 'notused'));
 define('ATTRIBUTES_LIST', '_attributes_list');
-define('ATTRIBUTES_LIST_INTERPOLATE', '_attributes_list_interpolate');
+define('ATTRIBUTES_INTERP', '_attributes_interp');
 
 
 if (!class_exists('Algolia_Send_Products')) {
@@ -252,8 +259,8 @@ if (!class_exists('Algolia_Send_Products')) {
             $setting_variation = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_VARIATION);
             $setting_ids = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_LIST);
             $setting_ids = explode(",", $setting_ids);
-            $setting_ids_interpolate = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_LIST_INTERPOLATE);
-            $setting_ids_interpolate = explode(",", $setting_ids_interpolate);
+            $setting_ids_interp = get_option(ALGOWOO_DB_OPTION . ATTRIBUTES_INTERP);
+            $setting_ids_interp = explode(",", $setting_ids_interp);
 
             if (!$rawAttributes) {
                 return false;
@@ -304,9 +311,9 @@ if (!class_exists('Algolia_Send_Products')) {
                     $tax_terms = array();
 
                     /**
-                     * interpolate all values when specified to interpolate
+                     * interp all values when specified to interp
                      */
-                    if (in_array($id, $setting_ids_interpolate)) {
+                    if (in_array($id, $setting_ids_interp)) {
                         $integers = array();
                         foreach ($terms as $term) {
                             array_push($integers, (int) $term->name);
@@ -321,7 +328,7 @@ if (!class_exists('Algolia_Send_Products')) {
                     /**
                      * normal mixed content case 
                      */
-                    if (!in_array($id, $setting_ids_interpolate)) {
+                    if (!in_array($id, $setting_ids_interp)) {
                         foreach ($terms as $term) {
                             $single_term = esc_html($term->name);
                             array_push($tax_terms, $single_term);

--- a/classes/class-send-products.php
+++ b/classes/class-send-products.php
@@ -45,12 +45,12 @@ define('BASIC_FIELDS', array(
     'tags',
     'categories',
     'short_description',
-
+    'long_description',
+    'excerpt',
     'product_image',
     'regular_price',
     'sale_price',
     'on_sale',
-    'attributes',
     "stock_quantity",
     "stock_status"
 ));
@@ -440,6 +440,8 @@ if (!class_exists('Algolia_Send_Products')) {
 
                 $record = self::add_to_record($record, 'product_name', $product->get_name());
                 $record = self::add_to_record($record, 'short_description', $product->get_short_description());
+                $record = self::add_to_record($record, 'long_description', $product->get_description());
+                $record = self::add_to_record($record, 'excerpt', get_the_excerpt($product->get_id()));
                 $record = self::add_to_record($record, 'regular_price', $regular_price);
                 $record = self::add_to_record($record, 'sale_price', $sale_price);
                 $record = self::add_to_record($record, 'on_sale', $product->is_on_sale());
@@ -462,10 +464,6 @@ if (!class_exists('Algolia_Send_Products')) {
                 $records[] = $record;
             }
 
-            echo "<pre>";
-            var_dump($records);
-            echo "</pre>";
-            die();
             wp_reset_postdata();
 
             /**

--- a/classes/class-send-products.php
+++ b/classes/class-send-products.php
@@ -124,6 +124,44 @@ if (!class_exists('Algolia_Send_Products')) {
         }
 
         /**
+         * Get product tags
+         *
+         * @param  mixed $product Product to check   
+         * @return array ['tag1', 'tag2', ...] simple array with associated tags
+         */
+        public static function get_product_tags($product)
+        {
+            $tags = get_the_terms($product->get_id(), 'product_tag');
+            $term_array = array();
+            foreach ($tags as $tag) {
+                $name = get_term($tag)->name;
+                array_push($term_array, $name);
+            }
+            return $term_array;
+        }
+
+        /**
+         * Get product categories
+         *
+         * @param  mixed $product Product to check   
+         * @return array ['tag1', 'tag2', ...] simple array with associated categories
+         */
+        public static function get_product_categories($product)
+        {
+            $categories = get_the_terms($product->get_id(), 'product_cat');
+            $term_array = array();
+            foreach ($categories as $category) {
+                $name = get_term($category)->name;
+                $slug = get_term($category)->slug;
+                array_push($term_array, array(
+                    "name" => $name, 
+                    "slug" => $slug
+                ));
+            }
+            return $term_array;
+        }
+
+        /**
          * Get attributes from product
          *
          * @param  mixed $product Product to check   
@@ -146,7 +184,7 @@ if (!class_exists('Algolia_Send_Products')) {
                 if ($attribute->is_taxonomy()) {
                     $terms = wp_get_post_terms($product->get_id(), $name, 'all');
                     $tax_terms = array();
-                    
+
                     // interpolate all values when found in numericRangeAttributes
                     if (array_search($name, $numericRangeAttributes, true) !== false) {
                         $integers = array();
@@ -278,6 +316,9 @@ if (!class_exists('Algolia_Send_Products')) {
                 $record['regular_price']                 = $regular_price;
                 $record['sale_price']                    = $sale_price;
                 $record['on_sale']                       = $product->is_on_sale();
+                $record['permalink']                     = $product->get_permalink();
+                $record['categories']                    = self::get_product_categories($product);
+                $record['tags']                          = self::get_product_tags($product);
                 $record['attributes']                    = self::get_product_attributes($product);
 
 
@@ -285,11 +326,11 @@ if (!class_exists('Algolia_Send_Products')) {
                  * Add stock information if stock management is on
                  */
                 $stock_data = self::get_product_stock_data($product);
-                if($stock_data) {
+                if ($stock_data) {
                     $record = array_merge($record, $stock_data);
                 }
 
-                
+
                 $records[] = $record;
             }
             wp_reset_postdata();

--- a/classes/class-verify-nonces.php
+++ b/classes/class-verify-nonces.php
@@ -30,13 +30,11 @@ if ( ! class_exists( 'Algolia_Verify_Nonces' ) ) {
 			 * Filter incoming nonces and values
 			 */
 			$settings_nonce = filter_input( INPUT_POST, 'algolia_woo_indexer_admin_api_nonce_name', FILTER_DEFAULT );
-
+			
 			/**
-			 * Return if if no nonce has been set for either of the two forms
+			 * Return boolean depending on if the nonce has been set
 			 */
-			if ( ! isset( $settings_nonce ) ) {
-				return;
-			}
+			return isset( $settings_nonce );
 
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: Daniel F
 Tags: algolia, woocommerce, search, algolia search, algolia indexing
 Requires at least: not tested
-Tested up to: 5.5.1
+Tested up to: 6.1.1
 Stable tag: 1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -21,7 +21,7 @@ You need to add the Application ID, the Admin API Key from the `API keys` sectio
 * Add the Application ID to the plugin settings page
 * Add the Admin API Key to the plugin settings page
 * Enter the name of the index that should be used to index Woocommerce products
-
+* Configure the fields to be indexed to your needs
 
 == Hooks ==
 n/a


### PR DESCRIPTION
Hi Daniel,

I've invested the whole day extending your plugin with some additional features.

**main added features**
- Added new fields
  - permalink
  - tags
  - categories
  - long_description
  - excerpt
  - stock_quantity,
  - stock_status
- Extend Backend
  - introduced new section for basic fields with simple checkboxes to enable or disable
- Added Logic for attributes
  - toggle to enable / disable attributes
  - Handling for the visibility boolean
  - Handling for the variation boolean
  - Whitelisting based on all existing WooCommerce attributes
  - Numeric interpolation (probably not the most used feature tho but had to do it for my client anyway)
- Fixed some bugs
  -  the `verify_settings_nonce` was inactive, `update_settings_options` has been called on every adminpage whatsoever.
  - downgraded requirements from PHP 8.1 down to PHP 8.0 due it is working perfectly well on PHP 8.0 (and WP 6.1.1 is yet not fully PHP 8.1 compatible)
- extended the readme slightly

**tested on**
- a quiet big WC instance with dozens of combinations (all latest versions
- clean fresh install (PHP 8.0, all latest versions)

**whats missing or could be further improved?**
- Didn't found a fast and simple way to extend the .pot file wihout paying licence fees (and loco translate doesn't recognize the new string). If you provide me an updated .pot file, I am happy to provide some nice human readable strings for the basic fields.
- screenshot could be updated after string translations
- the data structure of tags and categories is simply the label for now, could be also customizable to the needs - may some want the slug, description or so......

I hope i could fix the Codacy errors, was not able to set it up in a senseful timespan. if there are problems with it, please provide me some instruction :-) 

Greets Chris